### PR TITLE
Drop non-existent dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ catkin_package(
  #INCLUDE_DIRS include
  LIBRARIES image_to_file
  CATKIN_DEPENDS rospy std_msgs message_runtime
- DEPENDS system_lib
 )
 
 ###########


### PR DESCRIPTION
The following warning is issued when compiling rsync_ros -

CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'system_lib' but neither
  'system_lib_INCLUDE_DIRS' nor 'system_lib_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  notification_framework/rsync_ros/CMakeLists.txt:38 (catkin_package)

Turns out that system_lib is not an actual dependency but left-over
from generated template. Drop it as it's not needed. Also gets rid of
the warning.